### PR TITLE
chore: bump 0.20.0 and pin rust

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,3 @@
-# We need fmemopen in libsolv which became available in 10.13
-c_stdlib_version:          # [osx and x86_64]
-  - "10.13"                # [osx and x86_64]
+# We pin the compiler version to the same version as the one pinned in the repository
+rust_compiler_version:
+- 1.75.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rattler-build" %}
-{% set version = "0.19.0" %}
+{% set version = "0.20.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/prefix-dev/rattler-build/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: c9ca936aae5ba5e63115ad5076b29c8f7594adb3d588a29ebeeb0803152dd11e
+  sha256: 7e0b5d4e0aa77a8887d7441249d40f378261d74337c4e36fb3dd9340e8c365fb
 
 build:
   script:
@@ -30,13 +30,8 @@ build:
 requirements:
   build:
     - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
     - cargo-bundle-licenses
-    # to compile the libsolv parts
-    - {{ compiler('c') }}
-    - {{ stdlib("c") }}
-    - {{ compiler('cxx') }}
-    - cmake
-    - make  # [unix]
   host:
     - openssl  # [linux]
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I pinned the rust version to the one used in the repository to work around the issue reported in #76 . I also removed unused dependencies from #81 

Fixes #78
